### PR TITLE
Fixed keyboard navigation in flipped orientations

### DIFF
--- a/PSTreeGraphView/PSBaseTreeGraphView.m
+++ b/PSTreeGraphView/PSBaseTreeGraphView.m
@@ -932,16 +932,32 @@
                 [self toggleExpansionOfSelectedModelNodes:self];
                 break;
             case 'w':
-                [self moveUp:self];
+                if (self.treeGraphOrientation == PSTreeGraphOrientationStyleVerticalFlipped ) {
+                    [self moveDown:self];
+                } else {
+                    [self moveUp:self];
+                }
                 break;
             case 'a':
-                [self moveLeft:self];
+                if (self.treeGraphOrientation == PSTreeGraphOrientationStyleHorizontalFlipped ) {
+                    [self moveRight:self];
+                } else {
+                    [self moveLeft:self];
+                }
                 break;
             case 's':
-                [self moveDown:self];
+                if (self.treeGraphOrientation == PSTreeGraphOrientationStyleVerticalFlipped ) {
+                    [self moveUp:self];
+                } else {
+                    [self moveDown:self];
+                }
                 break;
             case 'd':
-                [self moveRight:self];
+                if (self.treeGraphOrientation == PSTreeGraphOrientationStyleHorizontalFlipped ) {
+                    [self moveLeft:self];
+                } else {
+                    [self moveRight:self];
+                }
                 break;
 
             default:


### PR DESCRIPTION
When orientation is HorizontalFlipped, reverse the meaning of a and d
keys.  When orientation is VerticalFlipped, reverse the meaning of w
and s keys.

I decided that  making the change in the key handling code in
insertText:(NSString_)theText was more intuitive than actually changing
the meaning of left, right, up, and down in the move_ methods.

My original intent with the flipped layout code was to make the change
as noninvasive as possible, this change is in keeping with that goal.
